### PR TITLE
Writes in home are not persistent

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -10,6 +10,7 @@
         "--share=network",
         "--socket=wayland",
         "--device=dri",
+        "--filesystem=home",
         "--talk-name=org.freedesktop.Notifications"
     ],
     "modules" : [


### PR DESCRIPTION
By installing the test build from the testing repository:
```
flatpak install --user https://dl.flathub.org/build-repo/10810/info.febvre.Komikku.flatpak
```
I realized that writes in home are not persistent.

Komikku writes its data in ~/Komikku (sqlite DB, pages scans).

@barthalion asks me to remove
```
        "--filesystem=home",
        "--filesystem=xdg-run/dconf",
        "--filesystem=~/.config/dconf:ro",
        "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
```

Should not we restored at least `--filesystem=home` permission?