### PR TITLE
New release 0.1.1

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -52,8 +52,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v0.1.0/Komikku-v0.1.0.tar.bz2",
-                    "sha256" : "23d55638162b0630b1503c11103dab1a406bf8e1cd6f2281ca9ca9b1dca309ca"
+                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v0.1.1/Komikku-v0.1.1.tar.bz2",
+                    "sha256" : "a8297ee0fa5abfde0be74587a0b1e8eed2ac5a929c047ce13e0fedc75f17ccd7"
                 }
             ]
         }


### PR DESCRIPTION
Data (SQLite DB and images scans) are now stored in XDG_DATA_HOME
(~/.var/app/info.febvre.Komikku/data) instead of ~/Komikku