### PR TITLE
New release 0.26.0

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -62,8 +62,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v0.25.1/Komikku-v0.25.1.tar.bz2",
-                    "sha256" : "0fd9b97477f12348b120966fc76c2350bd07a3d82d01d3010f26b1763413a9e9"
+                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v0.26.0/Komikku-v0.26.0.tar.bz2",
+                    "sha256" : "e89e8b281fd26ba5b7965125ba9a7621b2cc99c5e3959a9680c323f64c8625e1"
                 }
             ]
         }

--- a/python3-keyring.json
+++ b/python3-keyring.json
@@ -7,28 +7,28 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/e4/ed/7be20815f248b0d6aae406783c2bee392640924623c4e17b50ca90c7f74d/keyring-21.4.0-py3-none-any.whl",
-            "sha256": "4e34ea2fdec90c1c43d6610b5a5fafa1b9097db1802948e90caf5763974b8f8d"
+            "url": "https://files.pythonhosted.org/packages/96/17/86e1e5b50dc14e5984a661dde2ed3b7f05efe1fdee32145a77708cf06904/keyring-22.0.1-py3-none-any.whl",
+            "sha256": "9f44660a5d4931bdc14c08a1d01ef30b18a7a8147380710d8c9f9531e1f6c3c0"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/79/31/2e8d42727595faf224c6dbb748c32b192e212f25495fe841fb7ce8e168b8/jeepney-0.4.3-py3-none-any.whl",
-            "sha256": "d6c6b49683446d2407d2fe3acb7a368a77ff063f9182fe427da15d622adc24cf"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/c3/50/8a02cad020e949e6d7105f5f4530d41e3febcaa5b73f8f2148aacb3aeba5/SecretStorage-3.1.2-py3-none-any.whl",
-            "sha256": "b5ec909dde94d4ae2fa26af7c089036997030f0cf0a5cb372b4cccabd81c143b"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/5d/4b/7bb135c5787c003cdbc44990c5f41908f0f37135e0bb554e880d90fd5f6f/cryptography-3.1.1.tar.gz",
-            "sha256": "9d9fc6a16357965d282dd4ab6531013935425d0dc4950df2e0cf2a1b1ac1017d"
+            "url": "https://files.pythonhosted.org/packages/63/a2/a6d9099b14eb5dbbb04fb722d2b5322688f8f99b471bdf2097e33efa8091/SecretStorage-3.3.0-py3-none-any.whl",
+            "sha256": "5c36f6537a523ec5f969ef9fad61c98eb9e017bc601d811e53aa25bece64892f"
         },
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/ee/ff/48bde5c0f013094d729fe4b0316ba2a24774b3ff1c52d924a8a4cb04078a/six-1.15.0-py2.py3-none-any.whl",
             "sha256": "8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/51/b0/a6ea72741aaac3f37fb96d195e4ee576a103c4c04e279bc6b446a70960e1/jeepney-0.6.0-py3-none-any.whl",
+            "sha256": "aec56c0eb1691a841795111e184e13cad504f7703b9a64f63020816afa79a8ae"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/b7/82/f7a4ddc1af185936c1e4fa000942ffa8fb2d98cff26b75afa7b3c63391c4/cryptography-3.3.1.tar.gz",
+            "sha256": "7e177e4bea2de937a584b13645cab32f25e3d96fc0bc4a4cf99c27dc77682be6"
         }
     ]
 }


### PR DESCRIPTION
- Refined the ability to add comics via the command line: more servers supported
- [Explorer] Search: Add button to open server's website in browser
- [Explorer] Servers list: Add a 'key' icon when a server requires a user account
- [Explorer] Manga card: Add last chapter
- [Servers] Add Komga (Free and open source comics/mangas media server)
- [Servers] Add View Comics (EN)
- [Servers] MangaKawaii: Update
- [Servers] NineManga: Update
- [Servers] Scan Manga: Update
