### PR TITLE
New release 0.27.0

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -26,6 +26,7 @@
         "python3-unidecode.json",
         "python3-lxml.json",
         "python3-beautifulsoup4.json",
+        "python3-brotli.json",
         "python3-requests.json",
         {
             "name" : "libhandy",
@@ -48,7 +49,7 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/GNOME/libhandy.git",
-                    "tag" : "1.0.3"
+                    "tag" : "1.2.0"
                 }
             ]
         },
@@ -62,8 +63,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v0.26.1/Komikku-v0.26.1.tar.bz2",
-                    "sha256" : "a6a7170d381bd5351883c254cead838e9d674ae65c95d46e0f46f5588bbaf327"
+                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v0.27.0/Komikku-v0.27.0.tar.bz2",
+                    "sha256" : "d10816de6d0b6440f9ff19ee163661eca03ed1fbe674a47715df40bad774a20a"
                 }
             ]
         }

--- a/python3-brotli.json
+++ b/python3-brotli.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-brotli",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"brotli\""
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/2a/18/70c32fe9357f3eea18598b23aa9ed29b1711c3001835f7cf99a9818985d0/Brotli-1.0.9.zip",
+            "sha256": "4d1b810aa0ed773f81dceda2cc7b403d01057458730e309856356d4ef4188438"
+        }
+    ]
+}


### PR DESCRIPTION
- [Library] Add Categories to organize the library
- [Servers] Add Read Comics Online (EN)
- [Servers] Komga: Add sync (read progress) with server
- [Servers] JapScan: Partial fix (Webtoons chapters in single page are not handled)
- [Servers] MangaDex: Update
- [Servers] MangaKawaii: Update
- [Servers] MangaSee: Fix page download for chapters with decimals in name
- [Servers] Reaper Scans: Update
- [Servers] Scan Manga: Skip chapters coming from external servers
- [Servers] Tutto Anime Manga: Update
- [L10n] Add Italian translation
- [L10n] Update German translation