### PR TITLE
New release 0.28.1

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "info.febvre.Komikku",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "3.38",
+    "runtime-version" : "40",
     "sdk" : "org.gnome.Sdk",
     "command" : "komikku",
     "finish-args" : [
@@ -49,7 +49,7 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/GNOME/libhandy.git",
-                    "tag" : "1.2.0"
+                    "tag" : "1.2.2"
                 }
             ]
         },
@@ -63,8 +63,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v0.27.0/Komikku-v0.27.0.tar.bz2",
-                    "sha256" : "d10816de6d0b6440f9ff19ee163661eca03ed1fbe674a47715df40bad774a20a"
+                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v0.28.1/Komikku-v0.28.1.tar.bz2",
+                    "sha256" : "4a37915583ea75a499b458d6c70f4648afede213d9cf840f3a4aafebd7459fce"
                 }
             ]
         }


### PR DESCRIPTION
- Several UI changes to improve scaling on small devices screens
- [Library] Add categories edition in bulk (via multiple selection mode)
- [Reader] Fix memory leaks
- [Explorer] Allow search in servers list
- [Explorer] Added possibility to pin favorite servers
- [Updater] Prevents updating of comics whose server is disabled
- [Keyring] Improved SecretService detection
- [Servers] Add AllHentai (RU)
- [Servers] Add CatManga aka Black Cat Scanlations (EN)
- [Servers] Add Dongman Manhua (ZH Hans)
- [Servers] Add Madara (multi servers): Aloalivn (EN), Apoll Comics (ES), Wakascan (FR)24hRomance (EN), AkuManga (AR), ArazNovel (TR), Argos Scan (PT), Atikrost (TR)
- [Servers] Add MangaFreak (EN)
- [Servers] MangaSee: Update
- [Servers] Pepper&amp;Carrot: Fix pages order
- [Servers] Scantrad France: Update
- [Servers] Webtoon: Improved detail retrieval (both for originals and challenges)
- [L10n] Update French translation
- [L10n] Update German translation