### PR TITLE
New release 0.32.0

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -64,8 +64,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v0.31.0/Komikku-v0.31.0.tar.bz2",
-                    "sha256" : "5c56c52517453053a6d7110d824dfcf8b9e78ebaf7bf117ac6f10f33fe915543"
+                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v0.32.0/Komikku-v0.32.0.tar.bz2",
+                    "sha256" : "946e1665af1f10083cee07048a725ecda0a0e74846acb8bec62d2825272cd490"
                 }
             ]
         }


### PR DESCRIPTION
- [Library] Thumbnails: Fix rendering of servers logos and badges on mobile devices
- [Card] Fixed synopsis display when it contains HTML
- [Reader] Add option to hide page numbering
- [Reader] Fixed pager jumps when page rendering is retried
- [Explorer] Servers: Don't show Pinned when empty
- [Servers] Add Best Manga [RU]
- [Servers] Add Bilibili [EN]
- [Servers] Add Tapas [EN]
- [Servers] MangaDex: Update
