### PR TITLE
chore(update): org.gnome.Platform 41

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -30,31 +30,6 @@
         "python3-brotli.json",
         "python3-cloudscraper.json",
         {
-            "name" : "libhandy",
-            "buildsystem" : "meson",
-            "config-opts" : [
-                "--buildtype=release",
-                "-Dprofiling=false",
-                "-Dintrospection=enabled",
-                "-Dtests=false",
-                "-Dexamples=false",
-                "-Dgtk_doc=false",
-                "-Dvapi=false",
-                "-Dglade_catalog=disabled"
-            ],
-            "cleanup" : [
-                "/include",
-                "/lib/pkgconfig"
-            ],
-            "sources" : [
-                {
-                    "type" : "git",
-                    "url" : "https://gitlab.gnome.org/GNOME/libhandy.git",
-                    "tag" : "1.4.0"
-                }
-            ]
-        },
-        {
             "name" : "komikku",
             "buildsystem" : "meson",
             "builddir" : true,


### PR DESCRIPTION
Update to latest GNOME runtime and also drop libhandy dep. Libhandy now is a part of new GNOME runtime.