### PR TITLE
New release 0.36.0

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -30,6 +30,31 @@
         "python3-brotli.json",
         "python3-cloudscraper.json",
         {
+            "name" : "libhandy",
+            "buildsystem" : "meson",
+            "config-opts" : [
+                "--buildtype=release",
+                "-Dprofiling=false",
+                "-Dintrospection=enabled",
+                "-Dtests=false",
+                "-Dexamples=false",
+                "-Dgtk_doc=false",
+                "-Dvapi=false",
+                "-Dglade_catalog=disabled"
+            ],
+            "cleanup" : [
+                "/include",
+                "/lib/pkgconfig"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/GNOME/libhandy.git",
+                    "tag" : "1.5.0"
+                }
+            ]
+        },
+        {
             "name" : "komikku",
             "buildsystem" : "meson",
             "builddir" : true,

--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -39,8 +39,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v0.35.2/Komikku-v0.35.2.tar.bz2",
-                    "sha256" : "531f36a2a0ffe085af5f95964e05073b3eabf3c2f7b82298828336991764b55a"
+                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v0.36.0/Komikku-v0.36.0.tar.bz2",
+                    "sha256" : "77a5ef2703e3eaa2763ba968f5936cdf63dae65323aae6bacf78eb0b035428ec"
                 }
             ]
         }


### PR DESCRIPTION
- [Card] Add keyboard navigation outside of selection mode
- [Servers] CatManga: Disable
- [Servers] Lelscan-VF: Disable
- [Servers] ReaperScansFR: Disable
- [Servers] 24hRomance: Update
- [Servers] Asura Scans [EN/TR]: Update
- [Servers] Colored Manga (Colored Council): Update
- [Servers] Phoenix Fansub [ES]: Update
- [Servers] Raw Manga [JA]: Update
- [Servers] Rawkuma [JA]: Update
- [Servers] Submanga: Update
- [L10n] Update French and Spanish translations
