### PR TITLE
New release 0.37.0

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -50,7 +50,7 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/GNOME/libhandy.git",
-                    "tag" : "1.5.0"
+                    "tag" : "1.5.90"
                 }
             ]
         },
@@ -64,8 +64,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v0.36.1/Komikku-v0.36.1.tar.bz2",
-                    "sha256" : "fc0da6a3b9b196b69b45186f12f9088f042cb73131de43b8bc9e2dbd3eac5cc9"
+                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v0.37.0/Komikku-v0.37.0.tar.bz2",
+                    "sha256" : "5e4e220d4420a15aeef4fd074d1a848dfbee48027c7f6345d436b0546643b4ec"
                 }
             ]
         }


### PR DESCRIPTION
- Add `Quit` shortcut action (Ctrl+Q)
- [Servers] Fixed loading of images in `webp` format
- [Servers] Add GTO TGS [IT]
- [Servers] Add Phoenix Scans [IT]
- [Servers] Dragon Ball Multiverse: Update
- [Servers] Edelgarde Scans: Disabled
- [Servers] Hatigarm Scans: Disabled
- [Servers] Leomanga: Update
- [Servers] LupiTeam: Update
- [Servers] Nine Manga: Improved images loading
- [Servers] Wakascan: Disabled