### PR TITLE
New release 1.5.0

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -33,6 +33,7 @@
         "python3-brotli.json",
         "python3-cloudscraper.json",
         "python3-rarfile.json",
+        "python3-emoji.json",
         {
             "name": "gnustep-make",
             "buildsystem": "simple",

--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -102,8 +102,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v1.4.1/Komikku-v1.4.1.tar.bz2",
-                    "sha256" : "8761b3fa521fd8ec1b88b9a5fad0bc19893e0a8f497dbe2027da1b99e72297a2"
+                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v1.5.0/Komikku-v1.5.0.tar.bz2",
+                    "sha256" : "e0932d84eb82cc8832cc2709a80b58181ddb693a520eac6f9ddf01123711a83f"
                 }
             ]
         }

--- a/python3-emoji.json
+++ b/python3-emoji.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-emoji",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"emoji\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/56/3c/26aefc6bbfa015e1dabbabd6881103e236c7ae67fabb3265fef0c85e89b5/emoji-2.2.0.tar.gz",
+            "sha256": "a2986c21e4aba6b9870df40ef487a17be863cb7778dcf1c01e25917b7cd210bb"
+        }
+    ]
+}


### PR DESCRIPTION
- [Reader] Webtoon reading mode: Add srcolling with Page Up and Page Down keys
- [Explorer] Global search: Put servers without results at end
- [Preferences] Advanced: Add new option to disable GTK animations (useful with E Ink e-readers)
- [Servers] Add 3asq (مانجا العاش) [AR]
- [Servers] Apoll Comics: Update
- [Servers] Best Manga: Update
- [Servers] JapScan: Update
- [Servers] Lector Manga (Leomanga): Update
- [Servers] LeviatanScans: Update
- [Servers] Mangaowl: Update
- [Servers] Read Manga: Update
- [Servers] Remanga: Update
- [Servers] Xoxocomics: Update
- [Servers] Kirei Cake: Disable
