### PR TITLE
New release 1.12.0

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -103,8 +103,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v1.11.1/Komikku-v1.11.1.tar.bz2",
-                    "sha256" : "11c435282bd89304d9f205a356d58f17b6b9c6d428b3b61e7a9c1b358e459c27"
+                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v1.12.0/Komikku-v1.12.0.tar.bz2",
+                    "sha256" : "07c4aedb4c1745ab49682198e0aae26cfff047a237f70b76e0490e31fa3e34fb"
                 }
             ]
         }


### PR DESCRIPTION
- [UI] Added ability to go back with <ALT+Left> shortcut
- [Reader] Added ability to navigate foward with <SPACE> key
- [Servers] Guya.moe: Update
- [Servers] Manga/in/ua: Update
- [Servers] MangaFreak: Update
- [Servers] MangaHub: Update
- [Servers] MangaLib: Update
- [Servers] Mangas Origines: Update
- [Servers] Mangas.in: Update
- [Servers] Read Manga: Update
- [L10n] Updated French translation

Beware, all servers that contain explicit sexual content or nudity, such as hentai, ecchi and yaoi/yuri are now tagged NSFW.