### PR TITLE
New release 1.12.1

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -103,8 +103,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v1.12.0/Komikku-v1.12.0.tar.bz2",
-                    "sha256" : "07c4aedb4c1745ab49682198e0aae26cfff047a237f70b76e0490e31fa3e34fb"
+                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v1.12.1/Komikku-v1.12.1.tar.bz2",
+                    "sha256" : "0f7c72bee85fee52298fc097e9ce89c4ecb4a24c79d8a0a220378fc1091dbf84"
                 }
             ]
         }


### PR DESCRIPTION
Bugfix release

Fixed a bug that caused the loss of some pinned servers in the Explorer (it's certainly too late for those who have updated to version 1.12.0).

BEWARE, since 1.12.0, all servers that contain explicit sexual content or nudity, such as hentai, mature, ecchi or yaoi/yuri are now tagged NSFW (18+).