### PR TITLE
New release 1.24.1 (bugfix)

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -104,8 +104,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v1.24.0/Komikku-v1.24.0.tar.bz2",
-                    "sha256" : "af62a6000e6f8ef8dd21d5e1027cca177db9aaece2760f01873391fb00d05631"
+                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v1.24.1/Komikku-v1.24.1.tar.bz2",
+                    "sha256" : "b608c96a3732dd38d22260fb96178e3bebbd6e312ca8055c338c998b699d7689"
                 }
             ]
         }


### PR DESCRIPTION
Bugfix release: A regression prevented detection of the SecretService backend used for the keyring