### PR TITLE
New release 1.30.1 (bugfix)

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -98,7 +98,7 @@
         {
             "name": "blueprint-compiler",
             "buildsystem": "meson",
-            "builddir": true,
+            "cleanup": ["*"],
             "sources": [
                 {
                     "type": "archive",
@@ -117,8 +117,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v1.30.0/Komikku-v1.30.0.tar.bz2",
-                    "sha256" : "366540b50aeaad720926d2e6d3e82f567529c47d895732b4fc5372dd163ca301"
+                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v1.30.1/Komikku-v1.30.1.tar.bz2",
+                    "sha256" : "bbb26e020ac5877c886fb1c6351f77a09ee7fc74118bfd48b5fd513b065a8e8c"
                 }
             ]
         }


### PR DESCRIPTION
- [Library] Avoided simultaneous redisplays (lead to thumbnails duplication otherwise)
- [Card] Each time page is redisplayed, scrolling position of subpages (Infos, Chapters, Categories) is now reset to top
- [Servers] MangaReader: Added shuffled images decoding
- [Support] Added a new page to promote donating
- [L10n] Updated French and Polish translations