### PR TITLE
New release 1.34.2

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -117,8 +117,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v1.34.1/Komikku-v1.34.1.tar.bz2",
-                    "sha256" : "cfd71c9b9fc8fd26126bf650cc23fe556e71ce8375d80ccc53ed4a1f0a8f45c9"
+                    "url" : "https://gitlab.com/valos/Komikku/-/archive/v1.34.2/Komikku-v1.34.2.tar.bz2",
+                    "sha256" : "69010dde86cc2cb0a7de01a6e6fffde5f790b5d0ed2b4c444edd3d78d63b7cfd"
                 }
             ]
         }


### PR DESCRIPTION
- [Reader] Used best image scaling filter based on zoom value
- [Reader] Fixed memory leaks
- [Reader] RTL/LTR/Vertical pager: Fixed unzoom by double tap/click
- [Reader] Webtoon pager: Improved detection when first or last chapter is reached
- [Servers] Grise Bouille [FR]: Update
- [Servers] Toonily [EN]: Fix
- [L10n] Updated Chinese (Simplified), Finnish, Portuguese, Portuguese (Brazil) and Russian translations