### PR TITLE
New release 1.36.0

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -117,8 +117,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://codeberg.org/valos/Komikku/archive/v1.35.0.tar.gz",
-                    "sha256" : "32610f34f4c44ca7d25b45c559029609ac73aa6624fe7e2b0da294fe160d9c2b"
+                    "url" : "https://codeberg.org/valos/Komikku/archive/v1.36.0.tar.gz",
+                    "sha256" : "a5956057292b86872f4d6fce83001160b3fafecd24c5b843d3fdd358ae57208c"
                 }
             ]
         }


### PR DESCRIPTION
- [Reader] RTL/LTR/Vertical pager: Speed up white borders cropping
- [Servers] Izneo: Update
- [Servers] LegacyScans (FR): Update
- [Servers] Manhuaus (EN): Fixed manga statuses
- [Servers] MonkeyUser (EN): Update
- [Servers] NHentai (EN/JA/ZH): Added covers in searches results
- [Servers] Read Comic Online (EN): Update
- [Servers] Mangadoor (ES): Disable
- [L10n] Updated French translation