### PR TITLE
New release 1.38.0

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -117,8 +117,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://codeberg.org/valos/Komikku/archive/v1.37.1.tar.gz",
-                    "sha256" : "b4cc801cd152fcb1fc25cc16f6e45ffc62056fb3003e474ae38d90fdbfc39be9"
+                    "url" : "https://codeberg.org/valos/Komikku/archive/v1.38.0.tar.gz",
+                    "sha256" : "cec36c0d33697327db63b57e6ff0c45eb257d56b8aa7f7160d1c82cb3b01e226"
                 }
             ]
         }


### PR DESCRIPTION
- [Downloader] Improved error notification
- [Updater] Improved notifications
- [Updater] Prevent manga update from being scheduled while it's being updated
- [Servers] Armoni Scans (TR): Disable
- [Servers] Komga: Fixed missing covers in search
- [Servers] MangaHub (EN): Update
- [Servers] Manhuaus (EN): Update
- [Servers] Manhwa Hentai (EN): Update
- [Servers] Tapas (EN): Update
- [L10n] Updated Chinese (Traditional), French, Russian, Spanish, Turkish translations