### PR TITLE
New release 1.40.0

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -1,13 +1,10 @@
 {
     "app-id" : "info.febvre.Komikku",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "46beta",
+    "runtime-version" : "46",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"
-    ],
-    "tags" : [
-        "beta"
     ],
     "command" : "komikku",
     "finish-args" : [
@@ -30,12 +27,12 @@
         "python3-natsort.json",
         "python3-pillow.json",
         "python3-colorthief.json",
-        "python3-pure-protobuf.json",
         "python3-unidecode.json",
         "python3-lxml.json",
         "python3-beautifulsoup4.json",
         "python3-brotli.json",
         "python3-requests.json",
+        "python3-curl_cffi.json",
         "python3-rarfile.json",
         "python3-emoji.json",
         "python3-piexif.json",
@@ -115,13 +112,13 @@
             "buildsystem" : "meson",
             "builddir" : true,
             "config-opts" : [
-                "-Dprofile=beta"
+                "-Dprofile=default"
             ],
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://codeberg.org/valos/Komikku/archive/v1.40.beta1.tar.gz",
-                    "sha256" : "15f6d36b43461d1e811bf65996193905856cb16767ba957509304fa4164983c8"
+                    "url" : "https://codeberg.org/valos/Komikku/archive/v1.40.0.tar.gz",
+                    "sha256" : "53e102ceb5e6deacffb57b1fa1aced2cb2a736abf4b6c607b217c88e09779ad3"
                 }
             ]
         }

--- a/python3-cffi.json
+++ b/python3-cffi.json
@@ -7,8 +7,8 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/2b/a8/050ab4f0c3d4c1b8aaa805f70e26e84d0e27004907c5b8ecc1d31815f92a/cffi-1.15.1.tar.gz",
-            "sha256": "d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"
+            "url": "https://files.pythonhosted.org/packages/68/ce/95b0bae7968c65473e1298efb042e10cafc7bafc14d9e4f154008241c91d/cffi-1.16.0.tar.gz",
+            "sha256": "bcb3ef43e58665bbda2fb198698fcae6776483e0c4a631aa5647806c25e02cc0"
         },
         {
             "type": "file",

--- a/python3-curl_cffi.json
+++ b/python3-curl_cffi.json
@@ -1,0 +1,19 @@
+{
+    "name": "python3-curl_cffi",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"curl_cffi\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/ba/06/a07f096c664aeb9f01624f858c3add0a4e913d6c96257acb4fce61e7de14/certifi-2024.2.2-py3-none-any.whl",
+            "sha256": "dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/0c/48/8c79ea18592590eaf49c051398c911dca43482bee22688516539251dcbb9/curl_cffi-0.6.2.tar.gz",
+            "sha256": "9ee519e960b5fc6e0bbf13d0ecba9ce5f6306cb929354504bf03cc30f59a8f63"
+        }
+    ]
+}

--- a/python3-requests.json
+++ b/python3-requests.json
@@ -7,28 +7,28 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/d2/f4/274d1dbe96b41cf4e0efb70cbced278ffd61b5c7bb70338b62af94ccb25b/requests-2.28.2-py3-none-any.whl",
-            "sha256": "64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa"
+            "url": "https://files.pythonhosted.org/packages/ba/06/a07f096c664aeb9f01624f858c3add0a4e913d6c96257acb4fce61e7de14/certifi-2024.2.2-py3-none-any.whl",
+            "sha256": "dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl",
-            "sha256": "90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
+            "url": "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz",
+            "sha256": "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/71/4c/3db2b8021bd6f2f0ceb0e088d6b2d49147671f25832fb17970e9b583d742/certifi-2022.12.7-py3-none-any.whl",
-            "sha256": "4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"
+            "url": "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl",
+            "sha256": "c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/7b/f5/890a0baca17a61c1f92f72b81d3c31523c99bec609e60c292ea55b387ae8/urllib3-1.26.15-py2.py3-none-any.whl",
-            "sha256": "aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42"
+            "url": "https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl",
+            "sha256": "58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/ff/d7/8d757f8bd45be079d76309248845a04f09619a7b17d6dfc8c9ff6433cac2/charset-normalizer-3.1.0.tar.gz",
-            "sha256": "34e0a2f9c370eb95597aae63bf85eb5e96826d81e3dcf88b8886012906f509b5"
+            "url": "https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.whl",
+            "sha256": "450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"
         }
     ]
 }


### PR DESCRIPTION
- [UX] Refined visuals taking advantage of the new capabilities of GNOME 46
- [Servers] Added Lelmanga (FR)
- [Servers] Added Lelscan (FR)
- [Servers] Added Night scans (EN)
- [Servers] Comic Book Plus (EN): Fixed search
- [Servers] MANGA Plus by SHUEISHA: Update
- [Servers] MangaDex: Added Tags filter
- [Servers] MangaLib (RU): Update
- [Servers] Mangaowl (EN): Update
- [Servers] Jpmangas (FR): Disabled
- [Servers] Reaper Scans (pt_BR): Disabled
- [Servers] Scan FR: Disabled
- [Servers] Scan Manga (FR): Disabled
- [L10n] Updated French, Russian, Spanish and Turkish translations