### PR TITLE
New release 1.40.1

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -117,8 +117,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://codeberg.org/valos/Komikku/archive/v1.40.0.tar.gz",
-                    "sha256" : "53e102ceb5e6deacffb57b1fa1aced2cb2a736abf4b6c607b217c88e09779ad3"
+                    "url" : "https://codeberg.org/valos/Komikku/archive/v1.40.1.tar.gz",
+                    "sha256" : "8df5c718a26615646831db6450faeb685388a4bf874bb2695de5982138269ac0"
                 }
             ]
         }


### PR DESCRIPTION
This version fixes a bug in Preferences. Switching NFSW content switches caused the application to crash.

Changes in version 1.40.0
- [UX] Refined visuals taking advantage of the new capabilities of GNOME 46
- [Servers] Added Lelmanga (FR)
- [Servers] Added Lelscan (FR)
- [Servers] Added Night scans (EN)
- [Servers] Comic Book Plus (EN): Fixed search
- [Servers] MANGA Plus by SHUEISHA: Update
- [Servers] MangaDex: Added Tags filter
- [Servers] MangaLib (RU): Update
- [Servers] Mangaowl (EN): Update
- [Servers] Jpmangas (FR): Disabled
- [Servers] Reaper Scans (pt_BR): Disabled
- [Servers] Scan FR: Disabled
- [Servers] Scan Manga (FR): Disabled
- [L10n] Updated French, Russian, Spanish and Turkish translations