### PR TITLE
New release 1.41.1

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -117,8 +117,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://codeberg.org/valos/Komikku/archive/v1.41.0.tar.gz",
-                    "sha256" : "485c836037aef528f263a05412a0afd3f7fb0eef29a3d2e6ba088d52c7f0a5ad"
+                    "url" : "https://codeberg.org/valos/Komikku/archive/v1.41.1.tar.gz",
+                    "sha256" : "9d255b16c0686a6b791d72fe64091f97a935ad9d09ebe620dd4d67c673f1f5cd"
                 }
             ]
         }


### PR DESCRIPTION
This version fixes:
- A regression in Explorer, pinned servers list was no longer cleared when it was refreshed
- Wrong chapters order in Perf Scan (FR) server

Changes in previous version 1.41.0:
- [Servers] Added ComicExtra (EN)
- [Servers] Perf Scan (FR): Update
- [Servers] Mangas.in (ES: Update
- [Servers] Reaper Scans (EN): Update
- [L10n] Updated French, Russian, Spanish and Turkish translations