### PR TITLE
New release 1.45.1 (bugfix)

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -117,8 +117,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://codeberg.org/valos/Komikku/archive/v1.45.0.tar.gz",
-                    "sha256" : "9a268d87fc5fb410b9ff57acb283fe228c333d1fe913a26ae204b4fac0514bc6"
+                    "url" : "https://codeberg.org/valos/Komikku/archive/v1.45.1.tar.gz",
+                    "sha256" : "8483b62e941504f35a20512d4ca8cdee31943ea0b9564c212af399c0e8443702"
                 }
             ]
         }


### PR DESCRIPTION
This version fixes a bug that prevented some server logos from being displayed.

Changes in version 1.45.0:
- [Webview] Improved Cloudflare user challenge completion
- [Servers] Added Existential Comics (EN)
- [Servers] Added Manga Demon (EN)
- [Servers] Added MangaWeebs (EN)
- [Servers] Added Webtoon TR
- [Servers] Armoni Scans (Asura Scans TR): Reenabled
- [Servers] Atikrost (TR): Reenabled
- [Servers] Mangago (EN): Update
- [Servers] MangaFreak (EN): Update
- [Servers] Nine Manga (EN/PT_BR/DE/ES/FR/IT/RU): Update
- [L10n] Added Vietnamese translation
- [L10n] Updated French, German, Portuguese, Spanish and Russian translations