### PR TITLE
New release 1.58.0

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -120,8 +120,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://codeberg.org/valos/Komikku/archive/v1.57.0.tar.gz",
-                    "sha256": "4f42894d99077c1a9db671227608a699d712ea9b8fc64ff3be19894739123c45"
+                    "url": "https://codeberg.org/valos/Komikku/archive/v1.58.0.tar.gz",
+                    "sha256": "3c65b79517d7b8a838b40fe98b874cc944eacf9ba9f35a60d2601d6bd79b67f3"
                 }
             ]
         }


### PR DESCRIPTION
- Fixed display of covers in animated GIF format
- Fixed memory leaks
- [Servers] Added Manga Mana (FR)
- [Servers] Tecno Scan (ES): Reenable
- [Servers] Anteiku Scans (FR): Update
- [Servers] ComicExtra (EN): Update
- [Servers] ED Scanlation (FR): Update
- [Servers] EZmanga (EN): Update
- [Servers] Kewn Scans (EN): Update
- [Servers] MangaCrab (ES): Update
- [Servers] MangaWeebs (EN): Update
- [Servers] Reaper Scans (EN): Update
- [Servers] Scylla Comics (EN): Update
- [Servers] Starbound Scans (FR): Update
- [L10n] Update Portuguese (Brazil) translation