### PR TITLE
New release 1.66.0

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -120,8 +120,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://codeberg.org/valos/Komikku/archive/v1.65.0.tar.gz",
-                    "sha256": "e3216c0cb92e96913ec4155983cfa5b8fc3faf75b74f757bfd4a9128d5b68ed7"
+                    "url": "https://codeberg.org/valos/Komikku/archive/v1.66.0.tar.gz",
+                    "sha256": "cd1340b7c2f050a10b74e2df30b607ac5107e4ecc16c25388e0858dc39e89711"
                 }
             ]
         }


### PR DESCRIPTION
- [Servers] Added Asura Scans For Free (EN)
- [Servers] Asura Scans (EN): Update
- [Servers] MangaDex: Ignored externals and empty chapters
- [Servers] MangaDex: Added Genres filter
- [Servers] MangaHub: Avoided exceeding API rate limiting
- [Servers] MangaLib (RU): Update
- [Servers] Mangareader (to): Fixed decoding of scrumbled images
- [L10n] Updated Finnish, Portuguese (Brazil), Russian, Spanish, Swedish and Ukrainian translations