### PR TITLE
New release 1.69.0

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -120,8 +120,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://codeberg.org/valos/Komikku/archive/v1.68.0.tar.gz",
-                    "sha256": "d6db52db72da5d4c35b81b8e17ab9154cea7b8e03f96be2f4802cea6fbc3c692"
+                    "url": "https://codeberg.org/valos/Komikku/archive/v1.69.0.tar.gz",
+                    "sha256": "08943e8acff17cbb89a56ad2be745e84e5bb0670d72d3eef57f50f8b411efa65"
                 }
             ]
         }


### PR DESCRIPTION
- [Servers] EZmanga (EN): Update
- [Servers] Manga Demon (EN): Update
- [Servers] MangaHub (EN): Update
- [Servers] MangaWorld (IT): Update
- [Servers] Neko Scans (ES): Update
- [Servers] Sinensistoon (pt_BR): Renamed SCtoon (fusion with Cerise Scan)
- [Servers] Cerise Scan (pt_BR): Disabled
- [Servers] MangaLife (EN): Disabled
- [Servers] MangaSee (EN): Disabled
- [L10n] Added Czech translation