### PR TITLE
New release 1.73.0

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -119,7 +119,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://codeberg.org/valos/Komikku/archive/v1.73.0.tar.gz",
+                    "url": "https://codeberg.org/valos/Komikku/archive/1.73.0.tar.gz",
                     "sha256": "42b8c272ef1d1aaa466e0277ef28386247c3fd8309d26a8e47813d796d197a49"
                 }
             ]

--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -1,7 +1,7 @@
 {
     "app-id": "info.febvre.Komikku",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "47",
+    "runtime-version": "48",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"
@@ -119,8 +119,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://codeberg.org/valos/Komikku/archive/v1.72.0.tar.gz",
-                    "sha256": "dc3cb0b70c30f244f734d1c5386d661c8f5d854891b61241cb22416b5f0a125a"
+                    "url": "https://codeberg.org/valos/Komikku/archive/v1.73.0.tar.gz",
+                    "sha256": "42b8c272ef1d1aaa466e0277ef28386247c3fd8309d26a8e47813d796d197a49"
                 }
             ]
         }


### PR DESCRIPTION
GNOME 48 (libadwaita 1.7.0)

- [Library] Added ability to update with &lt;Ctrl+r&gt; shortcut
- [Card] Info: Improved display of Genres using badges
- [Servers] Added MangaBin (EN)
- [Servers] Added Vortex Scans For Free (EN)
- [Servers] Flame Comics (EN): Update
- [Servers] Manhuaus (EN): Update
- [Servers] Perf Scan (FR): Update
- [Servers] Remanga (RU): Update
- [L10n] Added Hungarian translation
