### PR TITLE
New release 1.78.0

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -119,8 +119,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "sha256": "f02bbbf64c9ba3def03c51d5d0071af0df89b1e875276a072e8de733deba328c",
-                    "url": "https://codeberg.org/valos/Komikku/archive/v1.77.0.tar.gz"
+                    "sha256": "000f07a4cbefb69fcacbdce270472124e2ca98c908387fb47c42e076589a26e0",
+                    "url": "https://codeberg.org/valos/Komikku/archive/v1.78.0.tar.gz"
                 }
             ]
         }


### PR DESCRIPTION
- [Card] Details page: Redesign
- [Servers] Local: Added support of CBT archive format (TAR)
- [Servers] Added Blue Solo (FR)
- [Servers] SMBC (EN): Re-enabled
- [Servers] Poseidon Scans (FR): Disabled
- [L10n] Updated Arabic, Bulgarian, Catalan and Portuguese (Brazil) translations