### PR TITLE
New release 1.88.0

### DIFF
--- a/info.febvre.Komikku.json
+++ b/info.febvre.Komikku.json
@@ -1,7 +1,7 @@
 {
     "app-id": "info.febvre.Komikku",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "48",
+    "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"
@@ -60,20 +60,21 @@
             "name": "gnustep",
             "buildsystem": "simple",
             "build-commands": [
-                "./configure --prefix=/app --enable-xml=no",
+                "./configure --prefix=/app --disable-xslt --disable-xml",
+                "sed -i 's/^#ADDITIONAL_CFLAGS +=.*/ADDITIONAL_CFLAGS += -std=gnu17/' Tools/Makefile.preamble",
                 "make -j $FLATPAK_BUILDER_N_JOBS install",
                 "ls /app/include"
             ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/gnustep/libs-base/releases/download/base-1_31_0/gnustep-base-1.31.0.tar.gz",
-                    "sha256": "d493ed2ba2a32f559f94e2ae5e339c440ae77d481dff1eb0d51eeac4d9127e33",
+                    "url": "https://github.com/gnustep/libs-base/archive/refs/tags/base-1_31_1.tar.gz",
+                    "sha256": "612e4415efc486c9e7017b00b28b0e122dc739d29b8e5d57ce79bf1a86a9862b",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 9105,
                         "stable-only": true,
-                        "url-template": "https://github.com/gnustep/libs-base/releases/download/base-$version/gnustep-base-1.$patch.0.tar.gz"
+                        "url-template": "https://github.com/gnustep/libs-base/archive/refs/tags/base-$version.tar.gz"
                     }
                 }
             ]
@@ -95,20 +96,6 @@
             ]
         },
         {
-            "name": "blueprint-compiler",
-            "buildsystem": "meson",
-            "cleanup": [
-                "*"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler/-/archive/v0.16.0/blueprint-compiler-v0.16.0.tar.bz2",
-                    "sha512": "9c8b3da532f7d9a36fa0993da295438afe57a5da03e122f3d9cc715dd7b7d99f2be52416f19a7a8d8523516f4f799cbb0a2c9ffafdef58a66163857542e5c8d7"
-                }
-            ]
-        },
-        {
             "name": "komikku",
             "buildsystem": "meson",
             "builddir": true,
@@ -118,8 +105,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "sha256": "051ed4e7ce9150d35a48a082199ec0021e11ca1b58ae694a52be85d297a9dcb7",
-                    "url": "https://codeberg.org/valos/Komikku/archive/v1.87.0.tar.gz"
+                    "sha256": "a0b1f4d7345fbda918198acfcd4902e5ce9fbad1a04054151203e7bd26d4c5dd",
+                    "url": "https://codeberg.org/valos/Komikku/archive/v1.88.0.tar.gz"
                 }
             ]
         }
@@ -128,6 +115,11 @@
         "append-path": "/usr/lib/sdk/rust-stable/bin"
     },
     "cleanup": [
+        "/include",
+        "/man",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man",
         "/bin/cvtenc",
         "/bin/autogsdoc",
         "/bin/debugapp",
@@ -144,9 +136,7 @@
         "/bin/sfparse",
         "/bin/xmlparse",
         "/etc/GNUstep",
-        "/include",
         "/lib/GNUstep",
-        "/share/GNUstep",
-        "/share/man"
+        "/share/GNUstep"
     ]
 }

--- a/python3-dateparser.json
+++ b/python3-dateparser.json
@@ -2,7 +2,7 @@
     "name": "python3-dateparser",
     "buildsystem": "simple",
     "build-commands": [
-        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"dateparser\" --no-build-isolation"
+        "pip3 install --verbose --exists-action=i --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"dateparser\" --no-build-isolation"
     ],
     "sources": [
         {
@@ -22,8 +22,8 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/8e/5f/bd69653fbfb76cf8604468d3b4ec4c403197144c7bfe0e6a5fc9e02a07cb/regex-2024.11.6.tar.gz",
-            "sha256": "7ab159b063c52a0333c884e4679f8d7a85112ee3078fe3d9004b2dd875585519"
+            "url": "https://files.pythonhosted.org/packages/b2/5a/4c63457fbcaf19d138d72b2e9b39405954f98c0349b31c601bfcb151582c/regex-2025.9.1.tar.gz",
+            "sha256": "88ac07b38d20b54d79e704e38aa3bd2c0f8027432164226bdee201a1c0c9c9ff"
         },
         {
             "type": "file",

--- a/python3-dateparser.json
+++ b/python3-dateparser.json
@@ -27,6 +27,11 @@
         },
         {
             "type": "file",
+            "url": "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl",
+            "sha256": "4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"
+        },
+        {
+            "type": "file",
             "url": "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl",
             "sha256": "eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d"
         }

--- a/python3-dateparser.json
+++ b/python3-dateparser.json
@@ -2,7 +2,7 @@
     "name": "python3-dateparser",
     "buildsystem": "simple",
     "build-commands": [
-        "pip3 install --verbose --exists-action=i --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"dateparser\" --no-build-isolation"
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"dateparser\" --no-build-isolation"
     ],
     "sources": [
         {

--- a/python3-modern-colorthief.json
+++ b/python3-modern-colorthief.json
@@ -7,14 +7,14 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/1f/be/47135bec8461339dab8ec8110afe496784f087485cf6007a355c3f47692b/modern_colorthief-0.1.7-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-            "sha256": "34d962f3aaeaaf929ba28577b6411c2277d8cc85a7cc12d70cc312d9d404cc7a",
+            "url": "https://files.pythonhosted.org/packages/c0/2c/e047e2016f9c364fc672a3b31668f6ad866358bb666e8311c284da4db6ff/modern_colorthief-0.1.7-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+            "sha256": "52a4c5b0a7865f9543712c2be168b3260bd0becbd0116bab3e69f3222c173906",
             "only-arches": ["x86_64"]
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/63/2e/76cc8c723f0e77731c0a1d7e111857ce327a417c12021c401d4e2525a5c9/modern_colorthief-0.1.7-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-            "sha256": "92e03ffb80b856eb57243affd1b138b8052165e8804b5edd45747d6a316c0f6f",
+            "url": "https://files.pythonhosted.org/packages/99/de/e0dd7a42dc94495462429608005ed802dd1ac4aaa3aa1c324f54a5b53397/modern_colorthief-0.1.7-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+            "sha256": "0160212a6334f2ef24aa2060c949ca72209bb89a6dca66e9b3a5c4cb747c16d7",
             "only-arches": ["aarch64"]
         }
     ]

--- a/python3-modern-colorthief.json
+++ b/python3-modern-colorthief.json
@@ -2,7 +2,7 @@
     "name": "python3-modern-colorthief",
     "buildsystem": "simple",
     "build-commands": [
-        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"modern-colorthief\" --no-build-isolation"
+        "pip3 install --verbose --exists-action=i --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"modern-colorthief\" --no-build-isolation"
     ],
     "sources": [
         {

--- a/python3-modern-colorthief.json
+++ b/python3-modern-colorthief.json
@@ -2,7 +2,7 @@
     "name": "python3-modern-colorthief",
     "buildsystem": "simple",
     "build-commands": [
-        "pip3 install --verbose --exists-action=i --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"modern-colorthief\" --no-build-isolation"
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"modern-colorthief\" --no-build-isolation"
     ],
     "sources": [
         {


### PR DESCRIPTION
- [UX] Refined visuals taking advantage of the new capabilities of GNOME 49
- [UI] Switching to Glycin (image loading framework)
- [Reader] Webtoon pager: Fixed small gap between pages
- [Servers] EZmanga (EN): Update
- [Servers] Grise Bouille (FR): Update
- [Servers] MangaCrab (ES): Update
- [Servers] Neko Scans (ES): Disabled
- [Servers] Qi Scans (Night scans): Update
- [L10n] Updated French, Portuguese, Portuguese (Brazil) and Ukrainian translations